### PR TITLE
Websubmit: categ referee vs general referee

### DIFF
--- a/modules/websubmit/web/yourapprovals.py
+++ b/modules/websubmit/web/yourapprovals.py
@@ -98,7 +98,7 @@ def index(req, c=CFG_SITE_NAME, ln=CFG_SITE_LANG, order="", doctype="", deletedI
                 req=req,
                 navmenuid='yourapprovals')
 
-def __isReferee(req, doctype="", categ="*"):
+def __isReferee(req, doctype="", categ=""):
     (auth_code, auth_message) = acc_authorize_action(req, "referee", doctype=doctype, categ=categ)
     if auth_code == 0:
         return 1


### PR DESCRIPTION
Category referee is considered as General Referee via Approval interface (your approvals) although user is only referee for one category #3527